### PR TITLE
update to rating popups and instant updates on read later page

### DIFF
--- a/packages/react-frontend/src/homepage/booktable.jsx
+++ b/packages/react-frontend/src/homepage/booktable.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import './bookTable.css';
 import { useAuth } from '../Auth';
-import { UncontrolledPopover, PopoverBody } from 'reactstrap'
+import { UncontrolledPopover, PopoverBody, PopoverHeader } from 'reactstrap'
 import { Rating } from '@smastrom/react-rating'
 import '@smastrom/react-rating/style.css'
 
@@ -114,13 +114,18 @@ const BookTable = ({ books }) => {
                             target={`ratingbutton-${book._id}`}
                             trigger='legacy'
                           >
+                            <PopoverHeader>
+                              <div style={{ color : 'black', padding : '5px' }}>
+                                Rate Book & Add to Library
+                              </div>
+                            </PopoverHeader>
                             <PopoverBody>
                               <Rating style={{ maxWidth: 200,
                                                padding: '10px' }}
                                       value={rating}
                                       onChange={setRating} />
                               <div style={{ padding: '10px',
-                                            paddingTop: '0px',
+                                            paddingTop: '2px',
                                             display: 'inline-block' }}>
                                 <button onClick={() => {rateBook(currentUser.uid, book, rating);}}>
                                   Rate

--- a/packages/react-frontend/src/library/booktable.jsx
+++ b/packages/react-frontend/src/library/booktable.jsx
@@ -34,6 +34,7 @@ const BookTable = ({ books }) => {
             if (result.status == 200) {
               setRateMessage("Rating updated.");
               setShowRateMessage(true);
+              book.ranking = rating;
             } else {
               setRateMessage("Unknown error occurred");
               setShowRateMessage(true);
@@ -65,7 +66,7 @@ const BookTable = ({ books }) => {
                         <td>{book.title}</td>
                         <td>{book.author}</td>
                         <td>{book.numPages}</td>
-                        <td>{book.ranking}</td>
+                        <td><b>{book.ranking}</b></td>
                         <td>
                             <button id={`ratingbutton-${book._id}`} type="button"
                                     onClick={() => { setSelectedBookId(book._id);
@@ -89,7 +90,7 @@ const BookTable = ({ books }) => {
                                 <div style={{ padding: '10px',
                                                 paddingTop: '0px',
                                                 display: 'inline-block' }}>
-                                    <button onClick={() => {rateBook(currentUser.uid, book, rating);}}>
+                                    <button onClick={() => { rateBook(currentUser.uid, book, rating); }}>
                                     Rate
                                     </button>
                                 </div>

--- a/packages/react-frontend/src/read-later/booktable.jsx
+++ b/packages/react-frontend/src/read-later/booktable.jsx
@@ -1,11 +1,49 @@
-import React from 'react';
+import React, { useState } from 'react';
 import './bookTable.css';
 import { useAuth } from '../Auth';
-
+import { UncontrolledPopover, PopoverBody, PopoverHeader } from 'reactstrap'
+import { Rating } from '@smastrom/react-rating'
+import '@smastrom/react-rating/style.css'
 
 const BookTable = ({ books, removeBook }) => {
 
     const { currentUser } = useAuth();
+
+    const [rating, setRating] = useState(0);
+    const [showRateMessage, setShowRateMessage] = useState(false);
+    const [selectedBookId, setSelectedBookId] = useState(null);
+    const [rateMessage, setRateMessage] = useState("Rating submitted.");
+
+    function rateBook(uid, book, rating) {
+        console.log("title: " + book.title + "\n rating: " + rating);
+          const rateData = {
+              by: uid,
+              about: book,
+              rating: rating
+            };
+      
+          const promise = fetch("http://localhost:8000/rateBook", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify(rateData)
+          });
+  
+          promise.then((result) => {
+            if (result.status == 406) {
+              setRateMessage("Use 'Library' tab to change rating");
+              setShowRateMessage(true);
+            } else if (result.status == 200) {
+              setRateMessage("Rating submitted");
+              setShowRateMessage(true);
+              removeBook(currentUser.uid, book);
+            } else {
+              setRateMessage("Unknown error occurred");
+              setShowRateMessage(true);
+            }
+          })
+      }
 
     return (
         <table className="book-table">
@@ -35,7 +73,48 @@ const BookTable = ({ books, removeBook }) => {
                         <td>{book.numPages}</td>
                         <td>{book.ranking}</td>
                         <td><button onClick={() => removeBook(currentUser.uid, book)}>Remove</button></td>
-                        <td><button onClick={() => handleRating(book)}>Rate It</button></td>
+                        <td>
+                          <button id={`ratingbutton-${book._id}`} type="button"
+                                  onClick={() => { setSelectedBookId(book._id);
+                                                   setShowRateMessage(false); }}
+                          >
+                            Rate It
+                          </button>
+                        </td>
+                        {selectedBookId === book._id && (
+                          <UncontrolledPopover
+                            className='popover'
+                            placement='top'
+                            target={`ratingbutton-${book._id}`}
+                            trigger='legacy'
+                          >
+                            <PopoverHeader>
+                              <div style={{ color : 'black', padding : '5px' }}>
+                                Rate Book & Add to Library
+                              </div>
+                            </PopoverHeader>
+                            <PopoverBody>
+                              <Rating style={{ maxWidth: 200,
+                                               padding: '10px' }}
+                                      value={rating}
+                                      onChange={setRating} />
+                              <div style={{ padding: '10px',
+                                            paddingTop: '2px',
+                                            display: 'inline-block' }}>
+                                <button onClick={() => {rateBook(currentUser.uid, book, rating);}}>
+                                  Rate
+                                </button>
+                              </div>
+                              <div style={{ color : 'maroon',
+                                            padding: '10px',
+                                            paddingLeft: '0px',
+                                            paddingTop: '0px',
+                                            display: 'inline-block' }}>
+                                { showRateMessage ? <text>{rateMessage}</text> : null }
+                              </div>
+                            </PopoverBody>
+                          </UncontrolledPopover>
+                        )}
                     </tr>
                 ))}
             </tbody>


### PR DESCRIPTION
This PR updates the ratings popups to be more user friendly. They now display text letting users know that when they rate a book it will be added to their library. I also fixed some formatting issues with the ratings popups.

Ratings popups have also now been added to the 'Read Later' page of the website. When a user rates a book from this page, if the rating successfully goes through, the book will automatically be moved from their Read Later list into their Library.

Additionally, a small fix for the library page has been implemented. This fix instantly updates the displayed user rating when the rating for a book is updated.

`note`: no new packages added